### PR TITLE
Support digital products and test urls

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,7 +21,7 @@ link = "plugins/themefisher-font/themefisher-font.min.css"
 [[params.plugins.css]]
 link = "plugins/slick/slick.min.css"
 [[params.plugins.css]]
-link = "https://cdn.snipcart.com/themes/v3.0.3/default/snipcart.css"
+link = "https://cdn.snipcart.com/themes/v3.0.6/default/snipcart.js"
 
 # JS Plugins
 [[params.plugins.js]]

--- a/layouts/products/single.html
+++ b/layouts/products/single.html
@@ -24,7 +24,11 @@
           data-item-id="{{.Title | urlize}}__{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}"
           data-item-name="{{.Title}}"
           data-item-image="{{range first 1 .Params.Images}}{{. | absURL}}{{end}}"
-          data-item-price="{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}" data-item-url="{{.Permalink}}" 
+          data-item-price="{{if .Params.discount_price}}{{.Params.discount_price}}{{else}}{{.Params.price}}{{end}}"
+          data-item-url="{{if .Params.url}}{{"https://"}}{{.Params.url}}{{else}}{{.Permalink}}{{end}}"
+          {{ if .Params.digital_guid }}
+          data-item-file-guid="{{.Params.digital_guid}}"
+          {{ end }}
           {{ if .Params.colors }}
           data-item-custom1-name="Choose Color"
           data-item-custom1-options="{{range $index, $element:= .Params.colors}}{{ if eq $index 0 }}{{. | title}}{{ else }}|{{. | title }}{{end}}{{end}}"


### PR DESCRIPTION
- support snipcart digital products available in v3.0.6.
- update snipcart to v 3.0.6.
- ability to add test-urls for offline snipcart testing via
ngrok or other tunneling apps.