### PR TITLE
Add custom styling and fix build process

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1,0 +1,8 @@
+.banner-title {
+  font-size: 55px;
+  line-height: 1.2;
+
+  @include mobile {
+    font-size: 40px;
+  }
+}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -11,7 +11,7 @@
 			</div>
 			<div class="col-md-6 align-self-center text-center text-md-left">
 				<div class="block">
-					<h1 class="font-weight-bold mb-4 font-size-60">{{ .title | markdownify }}</h1>
+					<h1 class="font-weight-bold mb-4 banner-title">{{ .title | markdownify }}</h1>
 					<p class="mb-4">{{ .content | markdownify }}</p>
 					{{ if .button.enable }}
 					{{ with .button }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,8 +13,15 @@
   <link rel="stylesheet" href="{{ .link | absURL }} ">
   {{ end }}
 
-  {{ "<!-- Main Stylesheet -->" | safeHTML }}
-  {{ $styles := resources.Get "scss/style.scss" | toCSS | minify }}
+  {{ "<!-- Theme Stylesheet -->" | safeHTML }}
+  {{$vexStyle := resources.Get "scss/style.scss" }}
+
+  {{ "<!-- Custom Stylesheet -->" | safeHTML }}
+  {{$customStyle := resources.Get "scss/custom.scss" }}
+
+  {{ "<!-- Unified Stylesheet -->" | safeHTML }}
+  {{ $unifiedStyle := slice $vexStyle $customStyle | resources.Concat "scss/main.scss" }} 
+  {{ $styles := $unifiedStyle | toCSS | minify }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" media="screen">
 
   {{ "<!--Favicon-->" | safeHTML }}


### PR DESCRIPTION
- Add custom scss style.
- Force build to concat scss files. In more recent versions of hugo,
we can use resources.GetMatch to retrieve all scss files. Perhaps later,
I can use wildcards with resources.Get to work around this.